### PR TITLE
Expand on server events

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ There are three different moves a player can make.
 - "step" just steps forward
 - "turn left" turns the player counterclockwise
 - "turn right" turns the player clockwise
+- "step back" ... well, does a backstep
 
 The player is only allowed to make a move, when it gets a signal to do so.
 Those signals will be sent out at fixed intervals.
@@ -67,6 +68,23 @@ and randomly placed on the map.
 Baits can be invisible.
 However, they will appear after a while.
 When "collecting" a trap, the player also gets teleported randomly to a different location on the map.
+
+Depending on the server configuration, invisible traps can be disarmed/uncovered by players.
+This happens randomly and depends on the configured probabilities.
+Also, collecting invisible gems can uncover all invisible baits.
+This is also a configurable probability.
+
+Forward steps are always allowed, if there is no wall.
+Otherwise, a "wall crash" happens, resulting in an error code and the client has to wait for the next signal.
+
+Backsteps, on the other hand, are only allowed, if there really is nothing behind.
+Baits can only be collected when stepping forward into them.
+The same is true for player collisions.
+When performing a backstep, while a player or bait is behind the player, a wall crash is triggered.
+
+When backstepping into an invisible trap, it is always "collected" and never disarmed/uncovered.
+When backstepping into any other bait, the bait in question is uncovered, but also a wall crash is triggered.
+The player has to turn around for actually collecting it.
 
 ### Game events
 
@@ -344,13 +362,13 @@ However, the techniques are pretty interesting and I will use that bot to furthe
 
 "mindripper" is not migrated yet, but I just postponed it to after I released this project.
 
-### "planewalker"
+### "planestrider"
 
 This is just an "underdog" without the mindreading ... or a "chopstick" that searches forwards ... or my very own
 "ninja", but not that "cool".
 
 It is actually a "new" bot, based on, what I now call, my "advanced bot family".
-In fact, "chopstick", "planewalker", "underdog", and "mindripper" all use the very same evaluation function.
+In fact, "chopstick", "planestrider", "underdog", and "mindripper" all use the very same evaluation function.
 "chopstick" would then be the "black sheep" of the family, because it uses its own maze structure and is implemented in
 Java.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 group=de.dreamcube.maze
-version=1.0.2026.1-SNAPSHOT
+version=1.0.2026.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 group=de.dreamcube.maze
-version=1.0.2025.5
+version=1.0.2026.1-SNAPSHOT

--- a/mazegame-client-ktor/doc/bot.md
+++ b/mazegame-client-ktor/doc/bot.md
@@ -26,12 +26,12 @@ This function also gives the dimensions of the maze.
 
 Let your strategy implement this interface and use the function to create your own data structure for the maze map.
 The length of the lines list should be identical to the parameter `height`.
-The length of each line should be identical to the parameter `with`.
+The length of each line should be identical to the parameter `width`.
 
 * Each `.` character is considered a "path" and therefore walkable.
 * Each `#` character is considered a "wall" and not walkable.
 * Each `-` character is considered "outside" and not walkable. Sometimes the outside fields are used inside for artistic
-  reasons. Just treat is as a different kind of "wall" and you will be fine.
+  reasons. Just treat it as a different kind of "wall" and you will be fine.
 * Every other character is considered "unknown" and not walkable. This should not be contained in the map data, but if
   it is, just treat it as outside or wall.
     * It is possible to get question marks. This is a sign for a badly configured server.
@@ -49,7 +49,7 @@ Here are some ideas/examples:
     * Might use an array as index structure
     * Used by more advanced bots (yes, there are also advanced bots, that use an array)
 * Something more exotic/eccentric
-    * Here your phantasy is the only limit
+    * Here your fantasy is the only limit
 
 ## React to game events
 
@@ -77,8 +77,9 @@ It also gives a Bait object, but in this case you want to remove it from your in
 
 Unlike baits, the corresponding
 [Player](../../mazegame-common/src/main/kotlin/de/dreamcube/mazegame/common/maze/player.kt) object is not immutable.
-The most important (literal) variables are the coordinates and the view direction.
-The mentioned object is the one that is internally used.
+The most important properties are the coordinates and the view direction.
+They change constantly while the player is moving.
+This is the internal object used by the client.
 
 The interface `PlayerMovementListener` handles events that are associated with the movement of players.
 The functions in this interface give you a so-called
@@ -88,13 +89,13 @@ This object is immutable and gives you a literal snapshot of the player's positi
 The player snapshot also contains a [PlayerView](../src/main/kotlin/de/dreamcube/mazegame/client/maze/PlayerView.kt).
 This is a read-only view of the above-mentioned internal player object.
 It gives you the current player information.
-The access, however, is not thread-safe.
+Access to it, however, is not thread-safe.
 Use it carefully.
 
 The function `onPlayerAppear` is only called once per player.
 When you log into the game, it is called once for all players that are currently playing for telling you their current
 position.
-When another player logs into the game, it is called once for telling your, where the server initially placed them.
+When another player logs into the game, it is called once for telling you, where the server initially placed them.
 It just contains the snapshot.
 The most important information are the id, the coordinates, and the view direction.
 If you include other players into your strategy, this function is very important to keep track of all players that are
@@ -153,7 +154,7 @@ This is a possibility that has not been explored yet.
 If you want to send a chat message yourself, just call the function `broadcast` or `whisper` on the `MazeClient`
 reference, which is part of your strategy object (super class).
 
-The server has two spam protection mechanism, an explicit and an implicit one.
+The server has two spam protection mechanisms, an explicit and an implicit one.
 The explicit spam protection limits the number of chat messages you can send.
 Every few milliseconds you get a "chat token" (you start with some), allowing you to send one message (chat or whisper).
 If your chat tokens are used up, you have to wait.
@@ -171,7 +172,7 @@ There are several event listener interfaces that provide you with information be
 The `PlayerConnectionListener` includes functions that inform you about new players joining and players leaving.
 The function `onPlayerLogin` is called right before the corresponding player appears in the maze.
 It is mostly used by the ui and for strategies it actually does not really matter if you react to this event or the
-player appear event from above.
+player appearance event from above.
 
 The function `onPlayerLogout` is called right after the corresponding player vanishes from the maze.
 Here the same reasoning applies.
@@ -196,7 +197,7 @@ If your strategy uses other classes that want to act as event listeners, this mi
 
 ### `beforeGoodbye`
 
-This function is called, right before your client sends logs out.
+This function is called, right before your client logs out.
 It is less useful but can be funny.
 
 ### `getNextMove`

--- a/mazegame-client-ktor/src/main/kotlin/de/dreamcube/mazegame/client/maze/messages.kt
+++ b/mazegame-client-ktor/src/main/kotlin/de/dreamcube/mazegame/client/maze/messages.kt
@@ -1,6 +1,6 @@
 /*
  * Maze Game
- * Copyright (c) 2025 Sascha Strauß
+ * Copyright (c) 2025-2026 Sascha Strauß
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import de.dreamcube.mazegame.common.maze.Message
 internal fun String.asMessage() = Message(this)
 
 private val stepMessage = "STEP".asMessage()
+private val backstepMessage = "BACK".asMessage()
 private val turnLeftMessage = "TURN;l".asMessage()
 private val turnRightMessage = "TURN;r".asMessage()
 
@@ -40,6 +41,7 @@ fun createByeMessage() = "BYE!".asMessage()
 
 // Movement
 fun createStepMessage() = stepMessage
+fun createBackstepMessage() = backstepMessage
 fun createTurnLeftMessage() = turnLeftMessage
 fun createTurnRightMessage() = turnRightMessage
 

--- a/mazegame-client-ktor/src/main/kotlin/de/dreamcube/mazegame/client/maze/strategy/Move.kt
+++ b/mazegame-client-ktor/src/main/kotlin/de/dreamcube/mazegame/client/maze/strategy/Move.kt
@@ -1,6 +1,6 @@
 /*
  * Maze Game
- * Copyright (c) 2025 Sascha Strauß
+ * Copyright (c) 2025-2026 Sascha Strauß
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,14 +38,19 @@ enum class Move {
     /**
      * Step forward.
      */
-    STEP;
+    STEP,
+
+    /**
+     * Step backwords.
+     */
+    BACK;
 
     /**
      * Determines the new [ViewDirection], if this [Move] is applied, while being in [viewDirectionBefore].
      */
     fun getViewDirectionAfter(viewDirectionBefore: ViewDirection) {
         when (this) {
-            DO_NOTHING, STEP -> viewDirectionBefore
+            DO_NOTHING, STEP, BACK -> viewDirectionBefore
             TURN_R -> viewDirectionBefore.turnRight()
             TURN_L -> viewDirectionBefore.turnLeft()
         }

--- a/mazegame-client-ktor/src/main/kotlin/de/dreamcube/mazegame/client/maze/strategy/Move.kt
+++ b/mazegame-client-ktor/src/main/kotlin/de/dreamcube/mazegame/client/maze/strategy/Move.kt
@@ -41,7 +41,7 @@ enum class Move {
     STEP,
 
     /**
-     * Step backwords.
+     * Step backwards.
      */
     BACK;
 

--- a/mazegame-client-ktor/src/main/kotlin/de/dreamcube/mazegame/client/maze/strategy/Strategy.kt
+++ b/mazegame-client-ktor/src/main/kotlin/de/dreamcube/mazegame/client/maze/strategy/Strategy.kt
@@ -17,10 +17,7 @@
 
 package de.dreamcube.mazegame.client.maze.strategy
 
-import de.dreamcube.mazegame.client.maze.MazeClient
-import de.dreamcube.mazegame.client.maze.createStepMessage
-import de.dreamcube.mazegame.client.maze.createTurnLeftMessage
-import de.dreamcube.mazegame.client.maze.createTurnRightMessage
+import de.dreamcube.mazegame.client.maze.*
 import de.dreamcube.mazegame.client.maze.events.*
 import de.dreamcube.mazegame.client.maze.events.EventListener
 import de.dreamcube.mazegame.common.maze.isNickValid
@@ -247,6 +244,7 @@ abstract class Strategy : NoEventListener {
         }
         when (move) {
             Move.STEP -> mazeClient.sendMessage(createStepMessage())
+            Move.BACK -> mazeClient.sendMessage(createBackstepMessage())
             Move.TURN_L -> mazeClient.sendMessage(createTurnLeftMessage())
             Move.TURN_R -> mazeClient.sendMessage(createTurnRightMessage())
             Move.DO_NOTHING -> {

--- a/mazegame-client-ktor/src/main/kotlin/de/dreamcube/mazegame/client/maze/strategy/VisualizationComponent.kt
+++ b/mazegame-client-ktor/src/main/kotlin/de/dreamcube/mazegame/client/maze/strategy/VisualizationComponent.kt
@@ -1,6 +1,6 @@
 /*
  * Maze Game
- * Copyright (c) 2025 Sascha Strauß
+ * Copyright (c) 2025-2026 Sascha Strauß
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import de.dreamcube.mazegame.client.maze.events.NoEventListener
 import java.awt.Color
 import java.awt.Graphics
 import java.awt.Point
+import java.util.concurrent.atomic.AtomicReference
 import javax.swing.JComponent
 
 /**
@@ -42,9 +43,17 @@ abstract class VisualizationComponent : JComponent(), NoEventListener {
     var visualizationEnabled = activateImmediately
 
     /**
-     * This map contains the color distribution for all player ids. Should only be set by the UI.
+     * This map contains the color distribution for all player ids. Should only be set by the UI. If you want to use it,
+     * use [colorDistributionMap] instead.
      */
-    var colorDistributionMap: Map<Int, Color> = mapOf()
+    var internalColorDistributionMap = AtomicReference<Map<Int, Color>>(mapOf())
+
+    /**
+     * This map contains the color distribution for all player ids. It refers to the atomic reference from
+     * [internalColorDistributionMap].
+     */
+    val colorDistributionMap: Map<Int, Color>
+        get() = internalColorDistributionMap.get()
 
     /**
      * The id of the selected player. Can be used for reacting to player selections in the visualization. Should only be

--- a/mazegame-common/src/main/kotlin/de/dreamcube/mazegame/common/api/GameSpeed.kt
+++ b/mazegame-common/src/main/kotlin/de/dreamcube/mazegame/common/api/GameSpeed.kt
@@ -24,20 +24,20 @@ import com.fasterxml.jackson.annotation.JsonValue
  * Enum class for the game speed. The values contain a [delay], indicating how much time should pass between the last
  * received move and the next "RDY." command. The [shortName] is used in DTO classes.
  */
-enum class GameSpeed(val delay: Long, @get:JsonValue val shortName: String) {
-    UNLIMITED(1L, "unlimited"),
-    RIDICULOUS(13L, "ridiculous"),
-    ULTRA(42L, "ultra"),
+enum class GameSpeed(val delay: Long, @get:JsonValue val shortName: String, val maxCompensation: Long = delay - 25L) {
+    LUDICROUS(0L, "ludicrous", 0L),
+    RIDICULOUS(25L, "ridiculous", 10L),
+    ULTRA(50L, "ultra", 40L),
     FAST(100L, "fast"),
     NORMAL(150L, "normal"),
     SLOW(200, "slow"),
-    ULTRA_SLOW(314, "ultra-slow");
+    ULTRA_SLOW(300, "ultra-slow");
 
     companion object {
         @JvmStatic
         @JsonCreator
         fun fromShortName(shortName: String): GameSpeed? = when (shortName) {
-            UNLIMITED.shortName -> UNLIMITED
+            LUDICROUS.shortName -> LUDICROUS
             RIDICULOUS.shortName -> RIDICULOUS
             ULTRA.shortName -> ULTRA
             FAST.shortName -> FAST

--- a/mazegame-common/src/main/kotlin/de/dreamcube/mazegame/common/api/GameSpeed.kt
+++ b/mazegame-common/src/main/kotlin/de/dreamcube/mazegame/common/api/GameSpeed.kt
@@ -1,6 +1,6 @@
 /*
  * Maze Game
- * Copyright (c) 2025 Sascha Strauß
+ * Copyright (c) 2025-2026 Sascha Strauß
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,17 +26,19 @@ import com.fasterxml.jackson.annotation.JsonValue
  */
 enum class GameSpeed(val delay: Long, @get:JsonValue val shortName: String) {
     UNLIMITED(1L, "unlimited"),
-    ULTRA(50L, "ultra"),
+    RIDICULOUS(13L, "ridiculous"),
+    ULTRA(42L, "ultra"),
     FAST(100L, "fast"),
     NORMAL(150L, "normal"),
     SLOW(200, "slow"),
-    ULTRA_SLOW(300, "ultra-slow");
+    ULTRA_SLOW(314, "ultra-slow");
 
     companion object {
         @JvmStatic
         @JsonCreator
         fun fromShortName(shortName: String): GameSpeed? = when (shortName) {
             UNLIMITED.shortName -> UNLIMITED
+            RIDICULOUS.shortName -> RIDICULOUS
             ULTRA.shortName -> ULTRA
             FAST.shortName -> FAST
             NORMAL.shortName -> NORMAL

--- a/mazegame-common/src/main/kotlin/de/dreamcube/mazegame/common/api/server_configuration.kt
+++ b/mazegame-common/src/main/kotlin/de/dreamcube/mazegame/common/api/server_configuration.kt
@@ -98,21 +98,17 @@ data class SpecialBotsDto(
 )
 
 /**
- * Can be used to map arbitrary server-sided bots to different additional nicknames. Their original strategy name is
- * always part of the internal set for determining the nickname.
+ * Can be used to map arbitrary server-sided bots to different additional nicknames.
  */
-data class FreeNickMapping(val botName: String, private val additionalNames: Set<String> = setOf()) {
-    val nickNames: Set<String>
-        get() = additionalNames + botName
-}
+data class FreeNickMapping(val botName: String, val nickNames: Set<String> = setOf())
 
 /**
  * Contains nickname mappings for server-sided bots. The original bot name is always implicitly included.
  */
 data class NickMappingsDto(
-    val dummyNames: Set<String>,
-    val trapeaterNames: Set<String>,
-    val frenzyNames: Set<String>,
+    val dummyNames: Set<String> = setOf(),
+    val trapeaterNames: Set<String> = setOf(),
+    val frenzyNames: Set<String> = setOf(),
     val freeNickMappings: List<FreeNickMapping> = listOf()
 )
 
@@ -125,11 +121,7 @@ data class ServerBotsDto(
     val autoLaunch: List<String> = listOf(),
     val autoLaunchDelay: Long = 1000L,
     val specialBots: SpecialBotsDto = SpecialBotsDto(),
-    val nickMappings: NickMappingsDto = NickMappingsDto(
-        setOf(specialBots.dummy),
-        setOf(specialBots.trapeater),
-        setOf(specialBots.frenzy)
-    )
+    val nickMappings: NickMappingsDto = NickMappingsDto()
 ) {
 
     @JsonIgnore

--- a/mazegame-common/src/main/kotlin/de/dreamcube/mazegame/common/api/server_configuration.kt
+++ b/mazegame-common/src/main/kotlin/de/dreamcube/mazegame/common/api/server_configuration.kt
@@ -188,8 +188,15 @@ data class SpecialEventsDto(
  * Contains the whole game configuration. The [initialSpeed] can be determined here. The default is [GameSpeed.NORMAL].
  * It can be specified whether baits should be generated right away with [generateBaitsAtStart]. The automatic trapeater
  * will only spawn if [autoTrapeater] is set. If [allowSpectator] is not set, the spectator mode is completely off.
- * The [delayCompensation] feature can also be configured here. For the other two configurations see [BaitGeneratorDto]
- * and [SpecialEventsDto].
+ * The [delayCompensation] feature can also be configured here.
+ *
+ * The following two are no special game events. They are tightly bound to invisible gems and invisible traps.
+ * - [uncoverInvisibleBaitsOnInvisibleGemProbability]: probability if all invisible baits should be uncovered if an
+ * invisible gem is collected. The default value is 0%.
+ * - [disarmInvisibleTrapProbability]: probability of bots being able to disarm invisible traps. They then either
+ * destroy them or place them behind themselves (this is always a 50:50 coin flip). The default value is 0%.
+ *
+ * For the other two configurations see [BaitGeneratorDto] and [SpecialEventsDto].
  */
 data class GameDto(
     val initialSpeed: GameSpeed = GameSpeed.NORMAL,
@@ -197,6 +204,8 @@ data class GameDto(
     val autoTrapeater: Boolean = true,
     val allowSpectator: Boolean = true,
     val delayCompensation: Boolean = true,
+    val uncoverInvisibleBaitsOnInvisibleGemProbability: Double = 0.0,
+    val disarmInvisibleTrapProbability: Double = 0.0,
     val baitGenerator: BaitGeneratorDto = BaitGeneratorDto(),
     val events: SpecialEventsDto = SpecialEventsDto()
 )

--- a/mazegame-common/src/main/kotlin/de/dreamcube/mazegame/common/api/server_configuration.kt
+++ b/mazegame-common/src/main/kotlin/de/dreamcube/mazegame/common/api/server_configuration.kt
@@ -161,26 +161,26 @@ data class BaitGeneratorDto(
  * [eventCooldown] is given in milliseconds. The default corresponds to 90 seconds. When an event occurs, at least that
  * amount of time will not contain further random events. The other values are probabilities (between 0 and 1):
  * - [allTrapProbability]: Whenever a gem is collected, it could be a "blood diamond", causing all baits to become
- * traps. The default probability is 1%.
+ * traps. The default probability is 0.5%.
  * - [allFoodProbability]: Whenever a coffee is collected, it could be a "coffee from the office machine", causing all
- * baits to become food. The default probability is 1%.
+ * baits to become food. The default probability is 0.5%.
  * - [allCoffeeProbability]: Whenever a player collision happens, there is a chance, that all baits transform into
- * coffee, because the causing player was "too tired" to pay attention. The default probability is 1%.
+ * coffee, because the causing player was "too tired" to pay attention. The default probability is 0.5%.
  * - [allGemProbability]: Whenever a food is collected, it could be an "enchanted golden apple" causing all baits to
- * be transformed into gems. The default probability is 0.5%.
+ * be transformed into gems. The default probability is 0.1%.
  * - [baitRushProbability]: Whenever an invisible trap is stepped on, there is a chance that a bait rush happens. The
- * default probability is 5%.
+ * default probability is 2,5%.
  * - [loseBaitProbability]: Whenever a player collision happens, there is also a chance that the causing player loses a
  * random bait at the collision location (and the corresponding points).
  */
 data class SpecialEventsDto(
     val enabled: Boolean = false,
     val eventCooldown: Long = 90_000,
-    val allTrapProbability: Double = 0.01,
-    val allFoodProbability: Double = 0.01,
-    val allCoffeeProbability: Double = 0.01,
-    val allGemProbability: Double = 0.005,
-    val baitRushProbability: Double = 0.05,
+    val allTrapProbability: Double = 0.005,
+    val allFoodProbability: Double = 0.005,
+    val allCoffeeProbability: Double = 0.005,
+    val allGemProbability: Double = 0.001,
+    val baitRushProbability: Double = 0.025,
     val loseBaitProbability: Double = 0.20
 )
 
@@ -192,9 +192,9 @@ data class SpecialEventsDto(
  *
  * The following two are no special game events. They are tightly bound to invisible gems and invisible traps.
  * - [uncoverInvisibleBaitsOnInvisibleGemProbability]: probability if all invisible baits should be uncovered if an
- * invisible gem is collected. The default value is 0%.
+ * invisible gem is collected. The default value is 50%.
  * - [disarmInvisibleTrapProbability]: probability of bots being able to disarm invisible traps. They then either
- * destroy them or place them behind themselves (this is always a 50:50 coin flip). The default value is 0%.
+ * destroy them or place them behind themselves (this is always a 50:50 coin flip). The default value is 30%.
  *
  * For the other two configurations see [BaitGeneratorDto] and [SpecialEventsDto].
  */
@@ -204,8 +204,8 @@ data class GameDto(
     val autoTrapeater: Boolean = true,
     val allowSpectator: Boolean = true,
     val delayCompensation: Boolean = true,
-    val uncoverInvisibleBaitsOnInvisibleGemProbability: Double = 0.0,
-    val disarmInvisibleTrapProbability: Double = 0.0,
+    val uncoverInvisibleBaitsOnInvisibleGemProbability: Double = 0.25,
+    val disarmInvisibleTrapProbability: Double = 0.3,
     val baitGenerator: BaitGeneratorDto = BaitGeneratorDto(),
     val events: SpecialEventsDto = SpecialEventsDto()
 )

--- a/mazegame-common/src/main/kotlin/de/dreamcube/mazegame/common/maze/player.kt
+++ b/mazegame-common/src/main/kotlin/de/dreamcube/mazegame/common/maze/player.kt
@@ -1,6 +1,6 @@
 /*
  * Maze Game
- * Copyright (c) 2025 Sascha Strauß
+ * Copyright (c) 2025-2026 Sascha Strauß
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -234,6 +234,20 @@ data class PlayerPosition(val x: Int, val y: Int, val viewDirection: ViewDirecti
             ViewDirection.NORTH -> y - 1
             ViewDirection.EAST, ViewDirection.WEST -> y
             ViewDirection.SOUTH -> y + 1
+        }
+        return PlayerPosition(newX, newY, viewDirection)
+    }
+
+    fun whenBackStep(): PlayerPosition {
+        val newX = when (viewDirection) {
+            ViewDirection.NORTH, ViewDirection.SOUTH -> x
+            ViewDirection.EAST -> x - 1
+            ViewDirection.WEST -> x + 1
+        }
+        val newY = when (viewDirection) {
+            ViewDirection.NORTH -> y + 1
+            ViewDirection.EAST, ViewDirection.WEST -> y
+            ViewDirection.SOUTH -> y - 1
         }
         return PlayerPosition(newX, newY, viewDirection)
     }

--- a/mazegame-common/src/main/kotlin/de/dreamcube/mazegame/common/maze/player.kt
+++ b/mazegame-common/src/main/kotlin/de/dreamcube/mazegame/common/maze/player.kt
@@ -152,6 +152,14 @@ enum class ViewDirection(val shortName: String) {
             SOUTH -> EAST
             WEST -> SOUTH
         }
+
+    fun backwards(): ViewDirection =
+        when (this) {
+            NORTH -> SOUTH
+            EAST -> WEST
+            SOUTH -> NORTH
+            WEST -> EAST
+        }
 }
 
 /**

--- a/mazegame-common/src/main/kotlin/de/dreamcube/mazegame/common/maze/text.kt
+++ b/mazegame-common/src/main/kotlin/de/dreamcube/mazegame/common/maze/text.kt
@@ -1,6 +1,6 @@
 /*
  * Maze Game
- * Copyright (c) 2025 Sascha Strauß
+ * Copyright (c) 2025-2026 Sascha Strauß
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ package de.dreamcube.mazegame.common.maze
 import java.text.Normalizer
 
 private val NICK_REGEX = """^[\p{L}&&\p{sc=Latin}](?:[\p{L}&&\p{sc=Latin}]|[0-9_-])*$""".toRegex()
-private val CHAT_BLACKLIST = """[^0-9_\-\p{Zs}[\p{L}&&\p{sc=Latin}][\p{Punct}&&[^;]]]""".toRegex()
+private val CHAT_BLACKLIST = """[^0-9_\-\p{Zs}[\p{L}&&\p{sc=Latin}][\p{Punct}&&[^;<>]]]""".toRegex()
 private const val FLAVOR_TEXT_MAX_LENGTH = 255
 
 /**

--- a/mazegame-server-ktor/doc/configuration.md
+++ b/mazegame-server-ktor/doc/configuration.md
@@ -161,6 +161,17 @@ It contains the following attributes that are explored one at a time.
   crafted approach for compensating the ping (and unfortunately also the computation time) of the bots. It has some
   "cheating potential", but if it is overdone, the mechanism resets and penalizes the cheater slightly. The current
   offset for each player can be queried using the server controls.
+- `uncoverInvisibleBaitsOnInvisibleGemProbability: Double`: Probability of uncovering all invisible baits when
+  collecting an invisible gem. The default is 0.0 (0%). If you set this value too high, you implicitly reduce the number
+  of invisible traps. Values up to 0.5 (50%) should be fine. Depending on the probability for invisible gems and the
+  placement of them, collecting them is fairly rare. If you configure this value too low, the event might not happen at
+  all.
+- `disarmInvisibleTrapProbability: Double`: Probability of bots disarming an invisible trap instead of falling for it.
+  The default is 0.0 (0%). If a trap is disarmed, another decision is made based on a 50:50 coin flip. The invisible
+  trap is either disarmed (destroyed) or "uncovered". Uncovering the trap places it behind the player, if this is
+  possible. If not, disarming is the fallback. In both cases the player loses 1 tick. Activating this mechanism slightly
+  reduces the variance of the game, while still having invisible traps around. Values up to 0.25 (25%) should be
+  acceptable. Higher values might defeat the purpose of invisible traps.
 - `baitGenerator: BaitGeneratorDto`: Configuration for the bait generation.
     - `objectDivisor: Int`: The number of baits is determined by the number of walkable fields divided by this number.
       The default value is 26. The value is coerced in the range `1..walkableFields`, resulting in having at least one

--- a/mazegame-server-ktor/doc/configuration.md
+++ b/mazegame-server-ktor/doc/configuration.md
@@ -162,16 +162,18 @@ It contains the following attributes that are explored one at a time.
   "cheating potential", but if it is overdone, the mechanism resets and penalizes the cheater slightly. The current
   offset for each player can be queried using the server controls.
 - `uncoverInvisibleBaitsOnInvisibleGemProbability: Double`: Probability of uncovering all invisible baits when
-  collecting an invisible gem. The default is 0.0 (0%). If you set this value too high, you implicitly reduce the number
+  collecting an invisible gem. The default is 0.25 (25%). If you set this value too high, you implicitly reduce the
+  number
   of invisible traps. Values up to 0.5 (50%) should be fine. Depending on the probability for invisible gems and the
   placement of them, collecting them is fairly rare. If you configure this value too low, the event might not happen at
   all.
 - `disarmInvisibleTrapProbability: Double`: Probability of bots disarming an invisible trap instead of falling for it.
-  The default is 0.0 (0%). If a trap is disarmed, another decision is made based on a 50:50 coin flip. The invisible
+  The default is 0.3 (30%). If a trap is disarmed, another decision is made based on a 50:50 coin flip. The invisible
   trap is either disarmed (destroyed) or "uncovered". Uncovering the trap places it behind the player, if this is
   possible. If not, disarming is the fallback. In both cases the player loses 1 tick. Activating this mechanism slightly
-  reduces the variance of the game, while still having invisible traps around. Values up to 0.25 (25%) should be
-  acceptable. Higher values might defeat the purpose of invisible traps.
+  reduces the variance of the game, while still having invisible traps around. Values up to 0.5 (50%) should be
+  acceptable. Higher values might defeat the purpose of invisible traps. However, if set too low, it encourages players
+  to "spam" backsteps. Disarming is only possible when stepping forwards. So this value should be higher than 0%.
 - `baitGenerator: BaitGeneratorDto`: Configuration for the bait generation.
     - `objectDivisor: Int`: The number of baits is determined by the number of walkable fields divided by this number.
       The default value is 26. The value is coerced in the range `1..walkableFields`, resulting in having at least one
@@ -190,17 +192,17 @@ It contains the following attributes that are explored one at a time.
     - `eventCooldown: Long`: Number of milliseconds in which no events will occur after an event happened. The default
       value is 90K, resulting in at lesat 90 seconds without events after each event.
     - `allTrapsProbability: Double`: Probability of transforming all baits into traps, whenever a gem is collected. The
-      default value is 0.01 (1%). If this happens, a trapeater is forced to spawn. If no trapeater exists, this event
+      default value is 0.005 (0.5%). If this happens, a trapeater is forced to spawn. If no trapeater exists, this event
       will not occur at all.
     - `allFoodProbability: Double`: Probabililty of transforming all baits into food, whenever a coffee is collected.
-      The default value is 0.01 (1%).
+      The default value is 0.005 (0.5%).
     - `allCoffeeProbability: Double`: Probability of transforming all baits into coffee, whenever two players collide.
-      The default value is 0.01 (1%).
+      The default value is 0.005 (0.5%).
     - `allGemProbability: Double`: Probability of transforming all baits into gems, whenever a food is collected. The
-      default value is 0.005 (0.5%).
+      default value is 0.001 (0.1%).
     - `baitRushProbability: Double`: Probability for a "bait rush", whenever an invisible trap is "collected". Whenever
       this event occurs, the number of baits is doubled for a certain amount of time (half of cooldown time). After that
-      time, no new baits will be generated, until the usual level is reached. The default value is 0.05(5%).
+      time, no new baits will be generated, until the usual level is reached. The default value is 0.025 (2.5%).
     - `loseBaitProbability: Double`: Probability of losing a bait on player collision. The bait will be lost by the
       player who ran into the other player (this is always unambiguous). The affected player will also lose the points
       associated with the bait. The default value is 0.2 (20%).

--- a/mazegame-server-ktor/doc/configuration.md
+++ b/mazegame-server-ktor/doc/configuration.md
@@ -128,17 +128,17 @@ It contains the following attributes that are explored one at a time.
       will be considered a spectator and never enter the maze and never receive a "RDY." command. This information is
       also part of the meta information to the client. Clients that can query for this information can automatically set
       the nickname correctly if the user just wants to spectate the game.
-- `nickMappings: NickMappingsDto`: Allows for custom nicknames for all server-sided bots. Defaults to "all bots should
-  only have their strategy name as nickname". The strategy name is always included. This option is also more of a "fun
-  option".
-    - `dummyNames: Set<String>`: Alternative names for dummy bots.
-    - `trapeaterNames: Set<String>`: Alternative names for the trapeater.
-    - `frenzyNames: Set<String>`: Alternative names for the frenzy bot.
+- `nickMappings: NickMappingsDto`: Allows for custom nicknames for all server-sided bots. If the corresponding
+  collection is empty, only the strategy name is used as nickname. If any of the sets is filled with at least one
+  nickname, the strategy name is not used as nickname, unless explicitly added. This option is more of a "fun option".
+    - `dummyNames: Set<String>`: Names for dummy bots.
+    - `trapeaterNames: Set<String>`: Names for the trapeater.
+    - `frenzyNames: Set<String>`: Names for the frenzy bot.
     - `freeNickMappings: List<FreeNickMapping>`: Mappings for all other bots, that are no "special" server bots. The
       default value is an empty list.
         - `botName`: The name of the strategy. Has to be set for every entry.
-        - `additionalNames`: besides the strategy names, this set contains all alternative names that might be used for
-          this bot strategy. The default value is an empty set.
+        - `nickNames`: This set contains all nicknames that should be used for the strategy. If you configure it empty,
+          the fallback is the strategy name, similarly to the special bots.
 
 ### Game configuration (`GameDto`)
 

--- a/mazegame-server-ktor/doc/protocol.md
+++ b/mazegame-server-ktor/doc/protocol.md
@@ -141,6 +141,21 @@ The client sends this message after `RDY.` if it wants to turn left or right.
 
 Example: `TURN;r`
 
+### Backstep (BACK)
+
+```
+Backstep ::= "BACK"
+```
+
+The client sends this message after `RDY.` if it wants to move one step opposite of the current view direction. This is
+effectively a backstep. Backsteps are only allowed, if the path behind the player is unoccupied. Visible baits and
+players are considered a wall and result in `INFO;453` (wall crash). Invisible traps are "collected". All other baits
+are uncovered, but the player has to turn around to collect it.
+
+#### Extensions
+
+The whole command is an extension.
+
 ### Bye (BYE!)
 
 ```
@@ -244,7 +259,7 @@ The following changes are possible and reflected by the reasons:
 - `tel` (teleport): The player is teleported to the given coordinates in the given view direction
 - `app` (appear): The player spawned at the given coordinates in the given view direction (after JOIN)
 - `van` (vanish): The player has vanished (after LEAVE)
-- `mov` (move): The player has moved to the given coordinates (after STEP)
+- `mov` (move): The player has moved to the given coordinates (after STEP or BACK)
 - `trn` (turn): The player has turned into the given view direction (after TURN)
 
 #### Extensions

--- a/mazegame-server-ktor/doc/protocol.md
+++ b/mazegame-server-ktor/doc/protocol.md
@@ -150,7 +150,7 @@ Backstep ::= "BACK"
 The client sends this message after `RDY.` if it wants to move one step opposite of the current view direction. This is
 effectively a backstep. Backsteps are only allowed, if the path behind the player is unoccupied. Visible baits and
 players are considered a wall and result in `INFO;453` (wall crash). Invisible traps are "collected". All other baits
-are uncovered, but the player has to turn around to collect it.
+are uncovered, but the player has to turn around to collect them.
 
 #### Extensions
 

--- a/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/contest/ContestController.kt
+++ b/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/contest/ContestController.kt
@@ -289,7 +289,8 @@ class ContestController(
 
     private fun GameSpeed.speedUp(): GameSpeed = when (this) {
         UNLIMITED -> UNLIMITED
-        ULTRA -> UNLIMITED
+        RIDICULOUS -> RIDICULOUS
+        ULTRA -> RIDICULOUS
         FAST -> ULTRA
         NORMAL -> FAST
         SLOW -> NORMAL
@@ -297,7 +298,8 @@ class ContestController(
     }
 
     private fun GameSpeed.slowDown(): GameSpeed = when (this) {
-        UNLIMITED -> ULTRA
+        UNLIMITED -> RIDICULOUS
+        RIDICULOUS -> ULTRA
         ULTRA -> FAST
         FAST -> NORMAL
         NORMAL -> SLOW

--- a/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/contest/ContestController.kt
+++ b/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/contest/ContestController.kt
@@ -288,7 +288,7 @@ class ContestController(
     }
 
     private fun GameSpeed.speedUp(): GameSpeed = when (this) {
-        UNLIMITED -> UNLIMITED
+        LUDICROUS -> LUDICROUS
         RIDICULOUS -> RIDICULOUS
         ULTRA -> RIDICULOUS
         FAST -> ULTRA
@@ -298,7 +298,7 @@ class ContestController(
     }
 
     private fun GameSpeed.slowDown(): GameSpeed = when (this) {
-        UNLIMITED -> RIDICULOUS
+        LUDICROUS -> RIDICULOUS
         RIDICULOUS -> ULTRA
         ULTRA -> FAST
         FAST -> NORMAL

--- a/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/ClientConnection.kt
+++ b/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/ClientConnection.kt
@@ -17,6 +17,7 @@
 
 package de.dreamcube.mazegame.server.maze
 
+import de.dreamcube.mazegame.common.api.GameSpeed
 import de.dreamcube.mazegame.common.maze.ConnectionStatus
 import de.dreamcube.mazegame.common.maze.InfoCode
 import de.dreamcube.mazegame.common.maze.Message
@@ -147,7 +148,9 @@ class ClientConnection(
     val performDelayCompensation: Boolean
         get() {
             val serverConfiguration = server.serverConfiguration
-            return serverConfiguration.game.delayCompensation && !(isServerSided && isSpecialNick(nick))
+            return serverConfiguration.game.delayCompensation &&
+                    server.gameSpeed != GameSpeed.LUDICROUS &&
+                    !(isServerSided && isSpecialNick(nick))
         }
 
     private fun isSpecialNick(nick: String): Boolean {
@@ -347,7 +350,9 @@ class ClientConnection(
         }
         val delayTime: Long = server.gameSpeed.delay + getDelayOffset()
         launch {
-            delay(delayTime)
+            if (delayTime > 0L) {
+                delay(delayTime)
+            }
             ready()
         }
         return movementAllowedByChatControl && movementAllowedByPenalty

--- a/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/ClientConnection.kt
+++ b/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/ClientConnection.kt
@@ -1,6 +1,6 @@
 /*
  * Maze Game
- * Copyright (c) 2025 Sascha Strauß
+ * Copyright (c) 2025-2026 Sascha Strauß
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ClosedSendChannelException
 import org.slf4j.LoggerFactory
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * This class represents a client connection. It contains coroutines for reading commands from and sending messages to a single client.
@@ -103,6 +104,11 @@ class ClientConnection(
      * Spam protection for the chat function.
      */
     val chatControl: ClientChatControl = ClientChatControl()
+
+    /**
+     * Allows for additional penalties caused by certain events.
+     */
+    val additionalTickPenalty = AtomicInteger(0)
 
     /**
      * This flag is set, whenever a ready-message is sent to the client.
@@ -330,7 +336,12 @@ class ClientConnection(
         if (performDelayCompensation) {
             delayCompensator.stopTimer()
         }
-        val movementAllowed: Boolean = chatControl.onMove()
+        val movementAllowedByChatControl: Boolean = chatControl.onMove()
+        val currentPenalty = additionalTickPenalty.get()
+        val movementAllowedByPenalty: Boolean = currentPenalty <= 0
+        if (currentPenalty > 0) {
+            additionalTickPenalty.decrementAndGet()
+        }
         if (server.frenzyHandler.active) {
             server.frenzyHandler.handle()
         }
@@ -339,7 +350,7 @@ class ClientConnection(
             delay(delayTime)
             ready()
         }
-        return movementAllowed
+        return movementAllowedByChatControl && movementAllowedByPenalty
     }
 }
 

--- a/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/MazeServer.kt
+++ b/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/MazeServer.kt
@@ -824,6 +824,8 @@ class MazeServer(
 
     internal suspend fun changeSpeed(newSpeed: GameSpeed) {
         gameSpeed = newSpeed
+        val allConnections = getAllPlayingPlayerConnections()
+        allConnections.forEach { connection -> connection.delayCompensator.resetTimer() }
         sendToAllPlayers(createSpeedChangeInfoMessage(newSpeed))
     }
 

--- a/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/MazeServer.kt
+++ b/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/MazeServer.kt
@@ -627,7 +627,7 @@ class MazeServer(
             if (bait.visibleToClients) {
                 add(createBaitCollectedMessage(bait).thereIsMore())
             } else {
-                bait.makeVisible()
+                bait.uncover()
                 if (bait.type == BaitType.TRAP) {
                     visibleTrapCount.incrementAndGet()
                 }
@@ -697,6 +697,17 @@ class MazeServer(
             }
             if (isNotEmpty()) {
                 add(createEmptyLastMessage())
+            }
+        }
+    }
+
+    /**
+     * Internal function for uncovering all invisible baits in the game.
+     */
+    internal suspend fun uncoverAllBaits() {
+        baitMutex.withLock {
+            baitsById.values.forEach { bait ->
+                bait.uncover()
             }
         }
     }

--- a/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/MazeServer.kt
+++ b/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/MazeServer.kt
@@ -221,11 +221,11 @@ class MazeServer(
         botNamesToPossibleNickNameMap = buildMap {
             val nickNameMappings: NickMappingsDto = serverConfiguration.serverBots.nickMappings
             val specialBots = serverConfiguration.serverBots.specialBots
-            put(specialBots.dummy, nickNameMappings.dummyNames + specialBots.dummy)
-            put(specialBots.trapeater, nickNameMappings.trapeaterNames + specialBots.trapeater)
-            put(specialBots.frenzy, nickNameMappings.frenzyNames + specialBots.frenzy)
+            this[specialBots.dummy] = nickNameMappings.dummyNames.ifEmpty { setOf(specialBots.dummy) }
+            this[specialBots.trapeater] = nickNameMappings.trapeaterNames.ifEmpty { setOf(specialBots.trapeater) }
+            this[specialBots.frenzy] = nickNameMappings.frenzyNames.ifEmpty { setOf(specialBots.frenzy) }
             for (currentMapping: FreeNickMapping in nickNameMappings.freeNickMappings) {
-                put(currentMapping.botName, currentMapping.nickNames)
+                this[currentMapping.botName] = currentMapping.nickNames.ifEmpty { setOf(currentMapping.botName) }
             }
         }
     }
@@ -770,10 +770,14 @@ class MazeServer(
     /**
      * Spawns a server-side bot.
      */
-    internal fun createServerSideClient(alias: String): ServerSideClient? {
+    internal suspend fun createServerSideClient(alias: String): ServerSideClient? {
         if (availableBotNames.contains(alias)) {
-            val possibleNickNames: Set<String> = botNamesToPossibleNickNameMap[alias] ?: setOf(alias)
-            return ClientWrapper.createServerSideClient(alias, port, possibleNickNames.random())
+            val configuredPossibleNickNames: Set<String> = botNamesToPossibleNickNameMap[alias] ?: setOf(alias)
+            // we filter out all nicknames that are not taken yet
+            val possibleNicknamesNotTakenYet = configuredPossibleNickNames.filter { !containsNick(it) }
+            // if all are taken, we go back to "totally random" and rely on the client to fallback on attaching numbers
+            val nicknamesToChooseFrom = possibleNicknamesNotTakenYet.ifEmpty { configuredPossibleNickNames }
+            return ClientWrapper.createServerSideClient(alias, port, nicknamesToChooseFrom.random())
         }
         return null
     }

--- a/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/ServerBait.kt
+++ b/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/ServerBait.kt
@@ -1,6 +1,6 @@
 /*
  * Maze Game
- * Copyright (c) 2025 Sascha Strauß
+ * Copyright (c) 2025-2026 Sascha Strauß
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ class ServerBait(var type: BaitType, val x: Int, val y: Int) {
         reappearTime = System.currentTimeMillis() + reappearOffset
     }
 
-    internal fun makeVisible() {
+    internal fun uncover() {
         visibleToClients = true
         reappearTime = 0L
     }
@@ -79,7 +79,7 @@ class ServerBait(var type: BaitType, val x: Int, val y: Int) {
         }
         val now = System.currentTimeMillis()
         if (now > reappearTime) {
-            makeVisible()
+            uncover()
         }
     }
 

--- a/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/commands/client/BackStepCommand.kt
+++ b/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/commands/client/BackStepCommand.kt
@@ -1,0 +1,104 @@
+/*
+ * Maze Game
+ * Copyright (c) 2026 Sascha Strauß
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.dreamcube.mazegame.server.maze.commands.client
+
+import de.dreamcube.mazegame.common.maze.*
+import de.dreamcube.mazegame.server.maze.*
+
+class BackStepCommand(clientConnection: ClientConnection, mazeServer: MazeServer, commandWithParameters: List<String>) :
+    ClientCommand(mazeServer, clientConnection) {
+
+    init {
+        if (commandWithParameters.size != 1) {
+            errorCode = InfoCode.WRONG_PARAMETER_VALUE
+        } else {
+            if (!clientConnection.isReady.get()) {
+                errorCode = InfoCode.ACTION_WITHOUT_READY
+            }
+        }
+        checkLoggedIn()
+    }
+
+    override suspend fun internalExecute() {
+        val movementAllowed = clientConnection.unready()
+        if (!movementAllowed) {
+            return
+        }
+        val player: Player = clientConnection.player
+
+        if (!mazeServer.maze.isWalkable(player.x, player.y, player.viewDirection.backwards())) {
+            errorCode = InfoCode.WALL_CRASH
+            return
+        }
+
+        val messagesForAll: MutableList<Message> = ArrayList()
+
+        val currentPosition = PlayerPosition(player.x, player.y, player.viewDirection)
+        val nextPosition = currentPosition.whenBackStep()
+        val (nX, nY, dir) = nextPosition
+
+        suspend fun move() {
+            mazeServer.changePlayerPosition(player, nX, nY, dir)
+            player.incrementMoveCounter()
+            messagesForAll.add(createPlayerPositionMoveMessage(player).thereIsMore())
+        }
+
+        if (mazeServer.maze.isOccupied(nX, nY)) {
+            // Backward movement is only allowed when the field "seems" free ... so invisible baits are okay, but
+            // everything else is not
+            val bait: ServerBait? = mazeServer.getBaitAt(nX, nY)
+            if (bait == null || bait.visibleToClients) {
+                // no bait -> must be a player, so we respond with a "wall crash"
+                // visible bait -> wall crash
+                errorCode = InfoCode.WALL_CRASH
+                return
+            }
+
+            // At this point we have an invisible bait
+            // An invisible gem (or coffee/food) becomes visible ... but we can't collect it
+            if (bait.type != BaitType.TRAP) {
+                bait.uncover()
+                errorCode = InfoCode.WALL_CRASH
+                // we don't return right away, because we need the replaceBait call below and sending all messages in the end
+            } else {
+                // we collect the bait and teleport the player
+                val removeMessage: Message? = mazeServer.removeBait(bait)
+                assert(removeMessage == null) // invisible baits don't yield a remove message
+                player.score += bait.type.score // decrease ... this is always a trap
+                messagesForAll.add(createPlayerScoreChangedMessage(player).thereIsMore())
+                messagesForAll.add(createServerInfoMessage("${player.nick} 'collected' an invisible trap with their rear end ... what a mess!"))
+                messagesForAll.add(mazeServer.teleportPlayerRandomly(player).thereIsMore())
+                // we also give a penalty
+                mazeServer.getClientConnection(player.id)?.additionalTickPenalty?.incrementAndGet()
+            }
+
+            // replace consumed bait ... required for uncovering and collecting
+            val newBaitMessages: List<Message> = mazeServer.replaceBaits()
+            if (newBaitMessages.isNotEmpty()) {
+                messagesForAll.addAll(newBaitMessages)
+            }
+        } else {
+            move()
+        }
+
+        if (messagesForAll.isNotEmpty()) {
+            messagesForAll.add(createEmptyLastMessage())
+        }
+        mazeServer.sendToAllPlayers(*messagesForAll.toTypedArray())
+    }
+}

--- a/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/commands/client/ChatCommand.kt
+++ b/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/commands/client/ChatCommand.kt
@@ -19,6 +19,7 @@ package de.dreamcube.mazegame.server.maze.commands.client
 
 import de.dreamcube.mazegame.common.maze.InfoCode
 import de.dreamcube.mazegame.common.maze.MAX_CHAT_LENGTH
+import de.dreamcube.mazegame.common.maze.sanitizeAsChatMessage
 import de.dreamcube.mazegame.server.maze.*
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -51,7 +52,7 @@ class ChatCommand(clientConnection: ClientConnection, mazeServer: MazeServer, co
                         message = ""
                         targetId = -1
                     } else {
-                        message = commandWithParameters[2]
+                        message = commandWithParameters[2].sanitizeAsChatMessage()
                         targetId = -1
                     }
                 }
@@ -62,7 +63,7 @@ class ChatCommand(clientConnection: ClientConnection, mazeServer: MazeServer, co
                         message = ""
                         targetId = -1
                     } else {
-                        message = commandWithParameters[2]
+                        message = commandWithParameters[2].sanitizeAsChatMessage()
                         targetId = commandWithParameters[3].toInt()
                     }
                 }

--- a/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/commands/client/ClientCommand.kt
+++ b/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/commands/client/ClientCommand.kt
@@ -1,6 +1,6 @@
 /*
  * Maze Game
- * Copyright (c) 2025 Sascha Strauß
+ * Copyright (c) 2025-2026 Sascha Strauß
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,6 +84,7 @@ fun createCommand(clientConnection: ClientConnection, mazeServer: MazeServer, ra
         when (command) {
             "STEP" -> StepCommand(clientConnection, mazeServer, commandWithParameters)
             "TURN" -> TurnCommand(clientConnection, mazeServer, commandWithParameters)
+            "BACK" -> BackStepCommand(clientConnection, mazeServer, commandWithParameters)
             "INFO" -> ChatCommand(clientConnection, mazeServer, commandWithParameters)
             "HELO" -> HelloCommand(clientConnection, mazeServer, commandWithParameters)
             "MAZ?" -> MazeQueryCommand(clientConnection, mazeServer, commandWithParameters)

--- a/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/commands/client/HelloCommand.kt
+++ b/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/commands/client/HelloCommand.kt
@@ -1,6 +1,6 @@
 /*
  * Maze Game
- * Copyright (c) 2025 Sascha Strauß
+ * Copyright (c) 2025-2026 Sascha Strauß
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@
 package de.dreamcube.mazegame.server.maze.commands.client
 
 import de.dreamcube.mazegame.common.maze.InfoCode
-import de.dreamcube.mazegame.common.maze.MAX_FLAVOR_LENGTH
 import de.dreamcube.mazegame.common.maze.MAX_NICK_LENGTH
 import de.dreamcube.mazegame.common.maze.isNickValid
+import de.dreamcube.mazegame.common.maze.sanitizeAsFlavorText
 import de.dreamcube.mazegame.server.maze.ClientConnection
 import de.dreamcube.mazegame.server.maze.MazeServer
 
@@ -41,12 +41,9 @@ class HelloCommand(clientConnection: ClientConnection, mazeServer: MazeServer, c
         } else {
             nick = commandWithParameters[1]
             flavor =
-                if (commandWithParameters.size > 2) commandWithParameters[2].trimToSize(MAX_FLAVOR_LENGTH) else null
+                if (commandWithParameters.size > 2) commandWithParameters[2].sanitizeAsFlavorText() else null
         }
     }
-
-    private fun String.trimToSize(maxLength: Int): String = if (this.length <= maxLength) this else
-        "${this.take(maxLength - 3)}..."
 
     override suspend fun internalExecute() {
         // we can't check the nick in the constructor, so we do it here

--- a/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/commands/client/StepCommand.kt
+++ b/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/commands/client/StepCommand.kt
@@ -1,6 +1,6 @@
 /*
  * Maze Game
- * Copyright (c) 2025 Sascha Strauß
+ * Copyright (c) 2025-2026 Sascha Strauß
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,10 @@ package de.dreamcube.mazegame.server.maze.commands.client
 
 import de.dreamcube.mazegame.common.maze.*
 import de.dreamcube.mazegame.server.maze.*
+import de.dreamcube.mazegame.server.maze.commands.control.OccupationResult
 import de.dreamcube.mazegame.server.maze.game_events.BaitCollectedEvent
 import de.dreamcube.mazegame.server.maze.game_events.GameEvent
+import de.dreamcube.mazegame.server.maze.game_events.GameEventControl
 import de.dreamcube.mazegame.server.maze.game_events.PlayerCollisionEvent
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -64,6 +66,12 @@ class StepCommand(clientConnection: ClientConnection, mazeServer: MazeServer, co
             ViewDirection.WEST -> nX -= 1
         }
 
+        suspend fun stepForward() {
+            mazeServer.changePlayerPosition(player, nX, nY, dir)
+            player.incrementMoveCounter()
+            messagesForAll.add(createPlayerPositionStepMessage(player).thereIsMore())
+        }
+
         if (mazeServer.maze.isOccupied(nX, nY)) {
             val bait: ServerBait? = mazeServer.getBaitAt(nX, nY)
             if (bait != null) {
@@ -76,15 +84,55 @@ class StepCommand(clientConnection: ClientConnection, mazeServer: MazeServer, co
                 player.score += bait.type.score
                 messagesForAll.add(createPlayerScoreChangedMessage(player).thereIsMore())
                 if (!bait.visibleToClients && bait.type != BaitType.TRAP) {
-                    messagesForAll.add(createServerInfoMessage("${player.nick} found an invisible ${bait.type.baitName}.").thereIsMore())
+                    val roll: Double = GameEventControl.rng.nextDouble()
+                    if (bait.type == BaitType.GEM && roll < 0.5) {
+                        messagesForAll.add(createServerInfoMessage("${player.nick} found an invisible ${bait.type.baitName} and uncovered all other invisible baits.").thereIsMore())
+                        mazeServer.uncoverAllBaits()
+                    } else {
+                        messagesForAll.add(createServerInfoMessage("${player.nick} found an invisible ${bait.type.baitName}.").thereIsMore())
+                    }
                 }
+
                 if (bait.type == BaitType.TRAP) {
-                    messagesForAll.add(mazeServer.teleportPlayerRandomly(player).thereIsMore())
+                    val roll: Double = GameEventControl.rng.nextDouble()
+                    if (!bait.visibleToClients && roll < mazeServer.serverConfiguration.game.disarmInvisibleTrapProbability) {
+                        // give them back the lost points ... it's clunky, but it will work
+                        player.score -= bait.type.score
+                        messagesForAll.add(createPlayerScoreChangedMessage(player).thereIsMore())
+
+                        fun disarm() {
+                            messagesForAll.add(createServerInfoMessage("${player.nick} successfully disarmed an invisible trap.").thereIsMore())
+                        }
+
+                        // We do a 50:50 coin flip. We either go for disarming or try to place the trap behind the player
+                        val reuseRoll: Double = GameEventControl.rng.nextDouble()
+                        if (reuseRoll < 0.5) {
+                            disarm()
+                        } else {
+                            // we try to place the trap behind the player
+                            val currentPosition = PlayerPosition(player.x, player.y, player.viewDirection)
+                            val behindPosition = currentPosition.whenBackStep()
+                            val (x, y, _) = behindPosition
+                            val (result, message) = mazeServer.putBait(BaitType.TRAP, x, y, true, 0L)
+
+                            if (result == OccupationResult.SUCCESS) {
+                                if (message != null) {
+                                    messagesForAll.add(message.thereIsMore())
+                                    messagesForAll.add(createServerInfoMessage("${player.nick} successfully uncovered an invisible trap.").thereIsMore())
+                                }
+                            } else {
+                                // If placing did not work, we go for disarming as fallback
+                                disarm()
+                            }
+                        }
+                        stepForward()
+                        // give them 1 tick of penalty ... disarming takes its time
+                        mazeServer.getClientConnection(player.id)?.additionalTickPenalty?.incrementAndGet()
+                    } else {
+                        messagesForAll.add(mazeServer.teleportPlayerRandomly(player).thereIsMore())
+                    }
                 } else {
-                    // step forward
-                    mazeServer.changePlayerPosition(player, nX, nY, dir)
-                    player.incrementMoveCounter()
-                    messagesForAll.add(createPlayerPositionStepMessage(player).thereIsMore())
+                    stepForward()
                 }
                 // replace consumed bait
                 val newBaitMessages: List<Message> = mazeServer.replaceBaits()
@@ -107,10 +155,7 @@ class StepCommand(clientConnection: ClientConnection, mazeServer: MazeServer, co
                 }
             }
         } else {
-            // step forward
-            mazeServer.changePlayerPosition(player, nX, nY, dir)
-            player.incrementMoveCounter()
-            messagesForAll.add(createPlayerPositionStepMessage(player).thereIsMore())
+            stepForward()
         }
         if (messagesForAll.isNotEmpty()) {
             messagesForAll.add(createEmptyLastMessage())

--- a/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/commands/client/StepCommand.kt
+++ b/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/commands/client/StepCommand.kt
@@ -37,10 +37,10 @@ class StepCommand(clientConnection: ClientConnection, mazeServer: MazeServer, co
     init {
         if (commandWithParameters.size != 1) {
             errorCode = InfoCode.WRONG_PARAMETER_VALUE
-        } else @Suppress("kotlin:S6518") // WTF? you serious?
-        if (!clientConnection.isReady.get()) {
-            errorCode = InfoCode.ACTION_WITHOUT_READY
-        }
+        } else
+            if (!clientConnection.isReady.get()) {
+                errorCode = InfoCode.ACTION_WITHOUT_READY
+            }
         checkLoggedIn()
     }
 
@@ -49,27 +49,23 @@ class StepCommand(clientConnection: ClientConnection, mazeServer: MazeServer, co
         if (!movementAllowed) {
             return
         }
-        val messagesForAll: MutableList<Message> = ArrayList()
-        var gameEvent: GameEvent? = null
         val player: Player = clientConnection.player
         if (!mazeServer.maze.isWalkable(player.x, player.y, player.viewDirection)) {
             errorCode = InfoCode.WALL_CRASH
             return
         }
-        var nX: Int = player.x
-        var nY: Int = player.y
-        val dir: ViewDirection = player.viewDirection
-        when (dir) {
-            ViewDirection.NORTH -> nY -= 1
-            ViewDirection.EAST -> nX += 1
-            ViewDirection.SOUTH -> nY += 1
-            ViewDirection.WEST -> nX -= 1
-        }
 
-        suspend fun stepForward() {
+        val messagesForAll: MutableList<Message> = ArrayList()
+        var gameEvent: GameEvent? = null
+
+        val currentPosition = PlayerPosition(player.x, player.y, player.viewDirection)
+        val nextPosition = currentPosition.whenStep()
+        val (nX, nY, dir) = nextPosition
+
+        suspend fun move() {
             mazeServer.changePlayerPosition(player, nX, nY, dir)
             player.incrementMoveCounter()
-            messagesForAll.add(createPlayerPositionStepMessage(player).thereIsMore())
+            messagesForAll.add(createPlayerPositionMoveMessage(player).thereIsMore())
         }
 
         if (mazeServer.maze.isOccupied(nX, nY)) {
@@ -110,7 +106,6 @@ class StepCommand(clientConnection: ClientConnection, mazeServer: MazeServer, co
                             disarm()
                         } else {
                             // we try to place the trap behind the player
-                            val currentPosition = PlayerPosition(player.x, player.y, player.viewDirection)
                             val behindPosition = currentPosition.whenBackStep()
                             val (x, y, _) = behindPosition
                             val (result, message) = mazeServer.putBait(BaitType.TRAP, x, y, true, 0L)
@@ -125,14 +120,14 @@ class StepCommand(clientConnection: ClientConnection, mazeServer: MazeServer, co
                                 disarm()
                             }
                         }
-                        stepForward()
+                        move()
                         // give them 1 tick of penalty ... disarming takes its time
                         mazeServer.getClientConnection(player.id)?.additionalTickPenalty?.incrementAndGet()
                     } else {
                         messagesForAll.add(mazeServer.teleportPlayerRandomly(player).thereIsMore())
                     }
                 } else {
-                    stepForward()
+                    move()
                 }
                 // replace consumed bait
                 val newBaitMessages: List<Message> = mazeServer.replaceBaits()
@@ -151,11 +146,11 @@ class StepCommand(clientConnection: ClientConnection, mazeServer: MazeServer, co
                     // step forward
                     mazeServer.changePlayerPosition(player, nX, nY, dir)
                     player.incrementMoveCounter()
-                    messagesForAll.add(createPlayerPositionStepMessage(player).thereIsMore())
+                    messagesForAll.add(createPlayerPositionMoveMessage(player).thereIsMore())
                 }
             }
         } else {
-            stepForward()
+            move()
         }
         if (messagesForAll.isNotEmpty()) {
             messagesForAll.add(createEmptyLastMessage())

--- a/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/delay_compensation/DelayCompensator.kt
+++ b/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/delay_compensation/DelayCompensator.kt
@@ -1,6 +1,6 @@
 /*
  * Maze Game
- * Copyright (c) 2025 Sascha Strauß
+ * Copyright (c) 2025-2026 Sascha Strauß
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ class DelayCompensator(private val clientConnection: ClientConnection, private v
     private var internalState: InternalState = InternalState.INITIALIZED
 
     val maxCompensation: Long
-        get() = server.gameSpeed.delay - 25L
+        get() = server.gameSpeed.maxCompensation
 
     var penaltyTime: Long = 0L
         internal set(penaltyTime) {

--- a/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/game_events/GameEventControl.kt
+++ b/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/game_events/GameEventControl.kt
@@ -1,6 +1,6 @@
 /*
  * Maze Game
- * Copyright (c) 2025 Sascha Strauß
+ * Copyright (c) 2025-2026 Sascha Strauß
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,10 +36,10 @@ class GameEventControl(private val server: MazeServer, private val parentScope: 
 
     companion object {
         private val LOGGER = LoggerFactory.getLogger(GameEventControl::class.java)
+        internal val rng = Random.Default
     }
 
     private val gameEventChannel = Channel<GameEvent>(Channel.UNLIMITED)
-    private val rng = Random.Default
     private val earliestNextEvent: AtomicLong = AtomicLong(0L)
 
     fun start() = launch {
@@ -130,6 +130,7 @@ class GameEventControl(private val server: MazeServer, private val parentScope: 
                     optionalMessage = "While ${causingPlayer.nick} ran into ${playerCollisionEvent.otherPlayer.nick}, they dropped a ${baitType.baitName}."
                 )
             )
+            activateCooldown()
         }
     }
 

--- a/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/messages.kt
+++ b/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/messages.kt
@@ -1,6 +1,6 @@
 /*
  * Maze Game
- * Copyright (c) 2025 Sascha Strauß
+ * Copyright (c) 2025-2026 Sascha Strauß
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,7 +97,7 @@ fun createPlayerPositionVanishMessage(player: Player) =
 fun createPlayerPositionTurnMessage(player: Player) =
     createPlayerPositionChangeMessage(player, PlayerPositionChangeReason.TURN).asMessage()
 
-fun createPlayerPositionStepMessage(player: Player) =
+fun createPlayerPositionMoveMessage(player: Player) =
     createPlayerPositionChangeMessage(player, PlayerPositionChangeReason.MOVE).asMessage()
 
 fun createPlayerTeleportMessage(player: Player) =

--- a/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/server_bots/AutoTrapeaterHandler.kt
+++ b/mazegame-server-ktor/src/main/kotlin/de/dreamcube/mazegame/server/maze/server_bots/AutoTrapeaterHandler.kt
@@ -1,6 +1,6 @@
 /*
  * Maze Game
- * Copyright (c) 2025 Sascha Strauß
+ * Copyright (c) 2025-2026 Sascha Strauß
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import de.dreamcube.mazegame.server.maze.MazeServer
 import kotlinx.coroutines.launch
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import kotlin.math.max
 import kotlin.math.round
 import kotlin.random.Random
 
@@ -147,7 +148,10 @@ class AutoTrapeaterHandler(mazeServer: MazeServer) : ServerBotHandler(mazeServer
      * Determines the new penalty time of the trapeater based on the currently visible fields.
      */
     private fun computeTrapeaterPenaltyTime(): Long {
-        val currentDelay = mazeServer.gameSpeed.delay
+        val currentDelay = max(
+            mazeServer.gameSpeed.delay,
+            1L // ensures at least 1ms delay ... important for "ludicrous", which is at 0
+        )
         val normalTrapeaterPenalty: Long = round(currentDelay.toDouble() * NORMAL_PENALTY_FRACTION).toLong()
         val penaltyDecreasePerTrap: Long = round(currentDelay.toDouble() * PENALTY_REDUCTION_PER_TRAP).toLong()
         return normalTrapeaterPenalty - (penaltyDecreasePerTrap * mazeServer.visibleTrapCount.get())

--- a/mazegame-ui/src/main/kotlin/de/dreamcube/mazegame/ui/LabelPane.kt
+++ b/mazegame-ui/src/main/kotlin/de/dreamcube/mazegame/ui/LabelPane.kt
@@ -1,0 +1,138 @@
+/*
+ * Maze Game
+ * Copyright (c) 2026 Sascha Strauß
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.dreamcube.mazegame.ui
+
+import de.dreamcube.mazegame.client.maze.PlayerSnapshot
+import de.dreamcube.mazegame.client.maze.events.PlayerMovementListener
+import de.dreamcube.mazegame.common.maze.PlayerPosition
+import de.dreamcube.mazegame.common.maze.TeleportType
+import de.dreamcube.mazegame.common.util.VisualizationHelper
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.awt.*
+import java.util.concurrent.atomic.AtomicReference
+import javax.swing.JComponent
+
+/**
+ * Part of the glass pane that can be activated. It shows the player names as label above them.
+ */
+class LabelPane() : JComponent(), PlayerMovementListener {
+
+    companion object {
+        private val BASE_FONT_LABEL = Font("SansSerif", Font.BOLD, 0)
+    }
+
+    /**
+     * Reference to the maze panel.
+     */
+    private val mazePanel: MazePanel
+        get() = UiController.mazePanel
+
+    /**
+     * The current zoom.
+     */
+    private val zoom
+        get() = mazePanel.zoom
+
+    /**
+     * The current offset (origin of the top-left pixel of the maze).
+     */
+    private val offset
+        get() = mazePanel.offset
+
+    private val qualityHints: RenderingHints = VisualizationHelper.createDefaultRenderingHints()
+
+    private val currentPlayerSnapshots: MutableMap<Int, PlayerSnapshot> = HashMap()
+
+    private val playerListMutex = Mutex()
+
+    internal var colorDistributionMap = AtomicReference<Map<Int, Color>>(mapOf())
+
+    override fun onPlayerAppear(playerSnapshot: PlayerSnapshot) {
+        UiController.bgScope.launch {
+            playerListMutex.withLock {
+                currentPlayerSnapshots[playerSnapshot.id] = playerSnapshot
+            }
+        }
+    }
+
+    override fun onPlayerStep(
+        oldPosition: PlayerPosition,
+        newPlayerSnapshot: PlayerSnapshot
+    ) {
+        UiController.bgScope.launch {
+            playerListMutex.withLock {
+                currentPlayerSnapshots[newPlayerSnapshot.id] = newPlayerSnapshot
+            }
+        }
+    }
+
+    override fun onPlayerTeleport(
+        oldPosition: PlayerPosition,
+        newPlayerSnapshot: PlayerSnapshot,
+        teleportType: TeleportType?,
+        causingPlayerId: Int?
+    ) {
+        UiController.bgScope.launch {
+            playerListMutex.withLock {
+                currentPlayerSnapshots[newPlayerSnapshot.id] = newPlayerSnapshot
+            }
+        }
+    }
+
+    override fun onPlayerVanish(playerSnapshot: PlayerSnapshot) {
+        UiController.bgScope.launch {
+            playerListMutex.withLock {
+                currentPlayerSnapshots.remove(playerSnapshot.id)
+            }
+        }
+    }
+
+    override fun paintComponent(g: Graphics?) {
+        val g2 = g as Graphics2D
+
+        g2.run {
+            setRenderingHints(qualityHints)
+            val playerSnapshots: List<PlayerSnapshot> = runBlocking {
+                playerListMutex.withLock {
+                    currentPlayerSnapshots.values.toList()
+                }
+            }
+            val colors = colorDistributionMap.get()
+            val labelFont = BASE_FONT_LABEL.deriveFont(zoom.toFloat() * 0.65f)
+            for (snapshot in playerSnapshots) {
+                val id = snapshot.id
+                val lX = offset.x + snapshot.x * zoom
+                val lY = offset.y + (snapshot.y - 1) * zoom // the label will be painted one field above
+
+                color = colors[id] ?: Color.darkGray
+                font = labelFont
+                VisualizationHelper.drawTextCentric(this, snapshot.nick, lX, lY, zoom, zoom)
+            }
+        }
+    }
+
+    internal suspend fun reset() {
+        isVisible = false
+        playerListMutex.withLock {
+            currentPlayerSnapshots.clear()
+        }
+    }
+}

--- a/mazegame-ui/src/main/kotlin/de/dreamcube/mazegame/ui/MainFrame.kt
+++ b/mazegame-ui/src/main/kotlin/de/dreamcube/mazegame/ui/MainFrame.kt
@@ -23,6 +23,7 @@ import de.dreamcube.mazegame.client.maze.events.PlayerConnectionListener
 import de.dreamcube.mazegame.client.maze.strategy.Strategy
 import de.dreamcube.mazegame.client.maze.strategy.VisualizationComponent
 import de.dreamcube.mazegame.common.maze.ConnectionStatus
+import de.dreamcube.mazegame.ui.UiController.labelPane
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -45,6 +46,7 @@ class MainFrame() : JFrame(TITLE), ClientConnectionStatusListener, PlayerConnect
         private const val VIS_BUTTON_TEXT_OFF = "Visualization: OFF"
         private const val VIS_POS = 1
         private const val MARK_POS = 2
+        private const val LABEL_POS = 3
     }
 
     /**
@@ -263,6 +265,13 @@ class MainFrame() : JFrame(TITLE), ClientConnectionStatusListener, PlayerConnect
         UiController.markerPane = markerPane
         UiController.addPlayerSelectionListener(markerPane)
         layeredGlassPane.add(markerPane, MARK_POS)
+
+        val labelPane = LabelPane()
+        labelPane.isVisible = false
+        UiController.labelPane = labelPane
+        UiController.prepareEventListener(labelPane)
+        layeredGlassPane.add(labelPane, LABEL_POS)
+
         this.glassPane = layeredGlassPane
         glassPane.isVisible = true
 
@@ -386,6 +395,7 @@ class MainFrame() : JFrame(TITLE), ClientConnectionStatusListener, PlayerConnect
                     leftSplitPane.add(scorePanel, JSplitPane.TOP)
                     connectionCounter += 1
                     leaveButton.isVisible = true
+                    labelPane.isVisible = true
                 }
 
                 ConnectionStatus.PLAYING -> {

--- a/mazegame-ui/src/main/kotlin/de/dreamcube/mazegame/ui/ScorePanel.kt
+++ b/mazegame-ui/src/main/kotlin/de/dreamcube/mazegame/ui/ScorePanel.kt
@@ -1,6 +1,6 @@
 /*
  * Maze Game
- * Copyright (c) 2025 Sascha Strauß
+ * Copyright (c) 2025-2026 Sascha Strauß
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ class ScorePanel() : JPanel() {
         get() = UiController.scoreTable
 
     var colorOptionsVisible = false
+    var labelsVisible = true
 
     init {
         layout = BorderLayout()
@@ -48,6 +49,21 @@ class ScorePanel() : JPanel() {
 
         val clearScoreButton = JButton("Clear Score")
         scoreButtonPanel.add(clearScoreButton, "sg unity")
+
+        val toggleLabelsButton = JButton("Hide labels")
+        toggleLabelsButton.addActionListener {
+            if (labelsVisible) {
+                labelsVisible = false
+                toggleLabelsButton.text = "Show labels"
+                UiController.labelPane.isVisible = false
+            } else {
+                labelsVisible = true
+                toggleLabelsButton.text = "Hide labels"
+                UiController.labelPane.isVisible = true
+            }
+        }
+        scoreButtonPanel.add(toggleLabelsButton, "span 2")
+
 
         val belowTablePanel = JPanel()
         belowTablePanel.layout = BorderLayout()

--- a/mazegame-ui/src/main/kotlin/de/dreamcube/mazegame/ui/ServerControlPanel.kt
+++ b/mazegame-ui/src/main/kotlin/de/dreamcube/mazegame/ui/ServerControlPanel.kt
@@ -643,13 +643,14 @@ class ServerControlPanel() : JPanel() {
             val shuffleAndReBait = JCheckBox("Shuffle and re-bait", true)
             add(shuffleAndReBait, SPAN_2)
 
-            val cancelButton = JButton("Cancel")
+            val cancelButton = JButton("Close")
             cancelButton.addActionListener {
                 this.dispose()
             }
             add(cancelButton, SG_UNITY)
 
             val startButton = JButton("Start")
+            startButton.font = startButton.font.deriveFont(Font.BOLD)
             startButton.addActionListener {
                 serverController.launch {
                     try {
@@ -738,13 +739,14 @@ class ServerControlPanel() : JPanel() {
             add(JLabel("Additional events"), SG_UNITY)
             add(readOnlyTextFieldWithContent(yesOrNo(configuration.additionalEvents.isNotEmpty())), SG_UNITY)
 
-            val okButton = JButton("OK")
+            val okButton = JButton("Close")
             okButton.addActionListener {
                 this.dispose()
             }
             add(okButton, SG_UNITY)
 
             val stopButton = JButton("Stop")
+            stopButton.font = stopButton.font.deriveFont(Font.BOLD)
             stopButton.addActionListener {
                 val result: Int = JOptionPane.showConfirmDialog(
                     this,

--- a/mazegame-ui/src/main/kotlin/de/dreamcube/mazegame/ui/StatusBar.kt
+++ b/mazegame-ui/src/main/kotlin/de/dreamcube/mazegame/ui/StatusBar.kt
@@ -1,6 +1,6 @@
 /*
  * Maze Game
- * Copyright (c) 2025 Sascha Strauß
+ * Copyright (c) 2025-2026 Sascha Strauß
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ class StatusBar() : JPanel(), ClientConnectionStatusListener, SpeedChangedListen
     /**
      * The flavor text of the own bot or the selected player.
      */
-    private val botFlavorTextLabel = JLabel()
+    private val botFlavorTextLabel = JLabel().also { it.putClientProperty("html.disable", true) }
 
     /**
      * Displays the current game speed.

--- a/mazegame-ui/src/main/kotlin/de/dreamcube/mazegame/ui/UiController.kt
+++ b/mazegame-ui/src/main/kotlin/de/dreamcube/mazegame/ui/UiController.kt
@@ -156,6 +156,11 @@ object UiController {
     internal var visualizationComponent: VisualizationComponent? = null
 
     /**
+     * Part of the glass pane for drawing the labels.
+     */
+    internal lateinit var labelPane: LabelPane
+
+    /**
      * Indicates if the server control is active.
      */
     internal val serverControllerActive: Boolean
@@ -289,10 +294,11 @@ object UiController {
         }
     }
 
-    internal fun reset() {
+    internal suspend fun reset() {
         mazePanel.reset()
         messagePane.reset()
         scoreTable.reset()
+        labelPane.reset()
     }
 
     internal fun triggerMazeUpdate(x: Int, y: Int) {
@@ -373,7 +379,8 @@ object UiController {
     }
 
     internal fun colorDistributionChanged(colorDistributionMap: Map<Int, Color>) {
-        visualizationComponent?.colorDistributionMap = colorDistributionMap
+        visualizationComponent?.internalColorDistributionMap?.set(colorDistributionMap)
+        labelPane.colorDistributionMap.set(colorDistributionMap)
     }
 
     internal fun activateControlButton() {


### PR DESCRIPTION
- New mini-events for invisible gems and traps
- Expanded on nickname/chat/flavor sanitation on the server-side (first part of #3 fix)
- Configured the status bar for not rendering HTML anymore (second part of #3 fix)
- Implemented "backsteps"
- Tweaked game speeds (now we have ridiculous and ludicrous)
- Introduced player labels in UI
- Improved UX for contest control

Fixes #3 